### PR TITLE
fix!: fix typo in OpenMixtral8x7b model name

### DIFF
--- a/src/v1/constants.rs
+++ b/src/v1/constants.rs
@@ -6,8 +6,8 @@ pub const API_URL_BASE: &str = "https://api.mistral.ai/v1";
 pub enum Model {
     #[serde(rename = "open-mistral-7b")]
     OpenMistral7b,
-    #[serde(rename = "open-mistral-8x7b")]
-    OpenMistral8x7b,
+    #[serde(rename = "open-mixtral-8x7b")]
+    OpenMixtral8x7b,
     #[serde(rename = "mistral-small-latest")]
     MistralSmallLatest,
     #[serde(rename = "mistral-medium-latest")]


### PR DESCRIPTION
## Description

`Model.OpenMistral8x7b` is renamed to `Model.OpenMixtral8x7b`.

## Related Issues & Pull Requests

- #7

## Checklist

- [x] I updated the documentation accordingly. Or I don't need to.
- [x] I updated the tests accordingly. Or I don't need to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed an enum variant to correct a spelling error, enhancing clarity in model identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->