### PR TITLE
feat(chat): add the 'system' and 'tool' message roles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test
 
-on: push
+on:
+  pull_request:
+  push:
 
 jobs:
   test:

--- a/src/v1/chat.rs
+++ b/src/v1/chat.rs
@@ -31,10 +31,14 @@ impl ChatMessage {
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ChatMessageRole {
+    #[serde(rename = "system")]
+    System,
     #[serde(rename = "assistant")]
     Assistant,
     #[serde(rename = "user")]
     User,
+    #[serde(rename = "tool")]
+    Tool,
 }
 
 // -----------------------------------------------------------------------------

--- a/src/v1/chat.rs
+++ b/src/v1/chat.rs
@@ -29,6 +29,7 @@ impl ChatMessage {
     }
 }
 
+/// See the [Mistral AI API documentation](https://docs.mistral.ai/capabilities/completion/#chat-messages) for more information.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub enum ChatMessageRole {
     #[serde(rename = "system")]


### PR DESCRIPTION
…ai/capabilities/completion/ )

## Description

In its current implementation, the mistral-ai client does not allow one to use the 'system' message role which can be used to customize the behavior of the agent as specified per the official documentation (https://docs.mistral.ai/capabilities/completion/). 
This PR simply intends to add those two roles to the library

## Checklist

- [x] I updated the documentation accordingly. Or I don't need to. (I did not need to)
- [x] I updated the tests accordingly. Or I don't need to. (I did not need to)
