### PR TITLE
Remove the `Content-Type` from the headers of the reqwest builders.

### DIFF
--- a/src/v1/client.rs
+++ b/src/v1/client.rs
@@ -384,7 +384,6 @@ impl Client {
         let request_builder = request
             .bearer_auth(&self.api_key)
             .header("Accept", "application/json")
-            .header("Content-Type", "application/json")
             .header("User-Agent", user_agent);
 
         request_builder
@@ -399,7 +398,6 @@ impl Client {
         let request_builder = request
             .bearer_auth(&self.api_key)
             .header("Accept", "application/json")
-            .header("Content-Type", "application/json")
             .header("User-Agent", user_agent);
 
         request_builder
@@ -414,7 +412,6 @@ impl Client {
         let request_builder = request
             .bearer_auth(&self.api_key)
             .header("Accept", "text/event-stream")
-            .header("Content-Type", "application/json")
             .header("User-Agent", user_agent);
 
         request_builder


### PR DESCRIPTION
## Description

fix #13 

A strange API error with code 400 not documented in the mistral.ai documentation.

## Checklist

- [x] I removed the header `Content-Type` from the reqwest builders (`Client::build_request`, `Client::build_request_async`, `Client::build_request_stream`). They apparently are conflicting with reqwest internal stufs.
