### PR TITLE
feat(constants): update model constants

### DIFF
--- a/src/v1/constants.rs
+++ b/src/v1/constants.rs
@@ -10,16 +10,22 @@ pub enum Model {
     OpenMixtral8x7b,
     #[serde(rename = "open-mixtral-8x22b")]
     OpenMixtral8x22b,
+    #[serde(rename = "open-mistral-nemo", alias = "open-mistral-nemo-2407")]
+    OpenMistralNemo,
     #[serde(rename = "mistral-tiny")]
     MistralTiny,
-    #[serde(rename = "mistral-small-latest")]
+    #[serde(rename = "mistral-small-latest", alias = "mistral-small-2402")]
     MistralSmallLatest,
-    #[serde(rename = "mistral-medium-latest")]
+    #[serde(rename = "mistral-medium-latest", alias = "mistral-medium-2312")]
     MistralMediumLatest,
-    #[serde(rename = "mistral-large-latest")]
+    #[serde(rename = "mistral-large-latest", alias = "mistral-large-2407")]
     MistralLargeLatest,
-    #[serde(rename = "codestral-latest")]
+    #[serde(rename = "mistral-large-2402")]
+    MistralLarge,
+    #[serde(rename = "codestral-latest", alias = "codestral-2405")]
     CodestralLatest,
+    #[serde(rename = "open-codestral-mamba")]
+    CodestralMamba,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]

--- a/tests/v1_constants_test.rs
+++ b/tests/v1_constants_test.rs
@@ -11,11 +11,14 @@ fn test_model_constant() {
         Model::OpenMistral7b,
         Model::OpenMixtral8x7b,
         Model::OpenMixtral8x22b,
+        Model::OpenMistralNemo,
         Model::MistralTiny,
         Model::MistralSmallLatest,
         Model::MistralMediumLatest,
         Model::MistralLargeLatest,
+        Model::MistralLarge,
         Model::CodestralLatest,
+        Model::CodestralMamba,
     ];
 
     let client = Client::new(None, None, None, None).unwrap();


### PR DESCRIPTION
## Description

- Add new models Mistral Nemo and Codestral Mamba
- Add aliases to models constant to be deserialized seemlessly from the versioned forme (e.g.: "mistral-large-2407")
- The commonly named Mistral Large 2 is now `constants::Model::MistralLargeLatest` when the old one is `Model::MistralLarge`

## Checklist

- [ ] I updated the tests accordingly. Or I don't need to.
